### PR TITLE
Update the "nan" dependence to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "js-yaml": "3.*",
-    "nan": "2.15.0",
+    "nan": "^2.17.0",
     "prebuild-install": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The old version of "nan" throw "message: error C2039: 'AccessorSignature': is not a member of 'v8'" when using ElectronJs.

Updating the version solved the problem.